### PR TITLE
Fix image aspect ratios to prevent cropping

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
       transition: transform 0.8s ease;
       perspective: 1000px;
       position: relative;
-      aspect-ratio: 1 / 1.2;
       display: flex;
     }
     .polaroid-inner {
@@ -52,8 +51,7 @@
       width: 100%;
       height: 100%;
       display: block;
-      object-fit: cover;
-      aspect-ratio: 1 / 1;
+      object-fit: contain;
     }
     .back {
       background: #fff;
@@ -93,6 +91,9 @@
         front.className = 'front';
         const img = document.createElement('img');
         img.src = baseURL + filename;
+        img.addEventListener('load', () => {
+          container.style.aspectRatio = `${img.naturalWidth} / ${img.naturalHeight}`;
+        });
         front.appendChild(img);
 
         const back = document.createElement('div');


### PR DESCRIPTION
## Summary
- avoid cropping by using `object-fit: contain`
- dynamically set `.polaroid` aspect ratio once an image loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848bc75be548320a34e041cfb554d9b